### PR TITLE
When Smarty returns error 422, parse and include the message in the SDK response.

### DIFF
--- a/lib/smartystreets_ruby_sdk/status_code_sender.rb
+++ b/lib/smartystreets_ruby_sdk/status_code_sender.rb
@@ -10,50 +10,49 @@ module SmartyStreets
     def send(request)
       response = @inner.send(request)
 
-      if response.status_code == '429'
-        response.error = parse_rate_limit_response(response)
-      end
-      assign_exception(response) if response.error == nil
+      message = response_message(response)
+
+      assign_exception(message, response) if response.error.nil?
 
       response
     end
 
-    def parse_rate_limit_response(response)
-      error_message = ""
-      if !response.payload.nil?
-        response_json = JSON.parse(response.payload)
-        response_json["errors"].each do |error|
-          error_message += (" " + error["message"])
-        end
-        error_message.strip!
-      end
-      if error_message == ""
-        error_message = TOO_MANY_REQUESTS
-      end
-      TooManyRequestsError.new(error_message)
+    def assign_exception(message, response)
+      response.error =
+        case response.status_code
+        when '401'
+          BadCredentialsError.new(BAD_CREDENTIALS)
+        when '402'
+          PaymentRequiredError.new(PAYMENT_REQUIRED)
+        when '413'
+          RequestEntityTooLargeError.new(REQUEST_ENTITY_TOO_LARGE)
+        when '400'
+          BadRequestError.new(BAD_REQUEST)
+        when '422'
+          UnprocessableEntityError.new(message || UNPROCESSABLE_ENTITY)
+        when '429'
+          TooManyRequestsError.new(message || TOO_MANY_REQUESTS)
+        when '500'
+          InternalServerError.new(INTERNAL_SERVER_ERROR)
+        when '503'
+          ServiceUnavailableError.new(SERVICE_UNAVAILABLE)
+        else
+          nil
+       end
     end
 
-    def assign_exception(response)
-      response.error = case response.status_code
-                         when '401'
-                           BadCredentialsError.new(BAD_CREDENTIALS)
-                         when '402'
-                           PaymentRequiredError.new(PAYMENT_REQUIRED)
-                         when '413'
-                           RequestEntityTooLargeError.new(REQUEST_ENTITY_TOO_LARGE)
-                         when '400'
-                           BadRequestError.new(BAD_REQUEST)
-                         when '422'
-                           UnprocessableEntityError.new(UNPROCESSABLE_ENTITY)
-                         when '429'
-                           TooManyRequestsError.new(TOO_MANY_REQUESTS)
-                         when '500'
-                           InternalServerError.new(INTERNAL_SERVER_ERROR)
-                         when '503'
-                           ServiceUnavailableError.new(SERVICE_UNAVAILABLE)
-                         else
-                           nil
-                       end
+    def response_message(response)
+      return unless response.payload
+
+      payload = JSON.parse(response.payload)
+
+      # For status 200, the payload is an Array. We exit in
+      # that case because the next line will crash
+      return unless payload.is_a?(Hash)
+
+      message = payload['errors'].map { |error| error['message'] }.join(', ')
+
+      message == '' ? nil : message
     end
   end
 end

--- a/test/smartystreets_ruby_sdk/test_status_code_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_status_code_sender.rb
@@ -78,6 +78,23 @@ class TestStatusCodeSender < Minitest::Test
     assert_equal(response.error, expected_exception)
   end
 
+  def test_422_return_payload_error_when_present
+    messages = ['Invalid Field 1', 'Invalid Field 2']
+    expected_message = messages.join(', ')
+    expected_exception = SmartyStreets::UnprocessableEntityError.new(expected_message)
+    payload = {"errors": [{message: 'Invalid Field 1'}, {message: 'Invalid Field 2'}]}
+    expected_response = Response.new(JSON.generate(payload), 422, nil, expected_exception)
+    inner = MockSender.new(expected_response)
+
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_response.error, response.error)
+    assert_equal(expected_exception, response.error)
+    assert_equal(expected_message, response.error.message)
+  end
+
   def test_too_many_requests_error_given_for_429
     expected_exception = SmartyStreets::TooManyRequestsError.new(SmartyStreets::TOO_MANY_REQUESTS)
     expected_response = Response.new(nil, '429', nil, expected_exception)


### PR DESCRIPTION
If SmartyAPI returns error messages for status 422, merge and ruturn those errors to the consumer of the SDK. This can happen if a bad country is specified for international api verification. This change allows the consumer of the SDK to receive a meaningful message about the error field so users can take the appropriate action.

Supercat source: SERV-1379